### PR TITLE
arm64: dts: qcom: Add Xiaomi Redmi Note 5A

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -63,6 +63,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-wingtech-wt86518.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-wingtech-wt86528.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-wingtech-wt88047.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8916-yiming-uz801v3.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= msm8917-xiaomi-ugglite.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8929-wingtech-wt82918hd.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8939-alcatel-idol3.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= msm8939-huawei-kiwi.dtb

--- a/arch/arm64/boot/dts/qcom/msm8917-xiaomi-ugglite.dts
+++ b/arch/arm64/boot/dts/qcom/msm8917-xiaomi-ugglite.dts
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2023, Barnabas Czeman
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/arm/qcom,ids.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/linux-event-codes.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+#include <dt-bindings/leds/common.h>
+#include "msm8917.dtsi"
+#include "pm8937.dtsi"
+
+/ {
+	model = "Xiaomi Redmi Note 5A (ugglite)";
+	compatible = "xiaomi,ugglite", "qcom,msm8917";
+	chassis-type = "handset";
+
+	qcom,msm-id = <QCOM_ID_MSM8917 0>, <QCOM_ID_MSM8217 0>, <QCOM_ID_MSM8617 0>;
+	qcom,board-id = <QCOM_BOARD_ID_MTP 0>;
+
+	chosen {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		stdout-path = "framebuffer0";
+
+		framebuffer0: framebuffer@90001000 {
+			compatible = "simple-framebuffer";
+			reg = <0x0 0x90001000 0x0 (720 * 1280 * 3)>;
+			width = <720>;
+			height = <1280>;
+			stride = <(720 * 3)>;
+			format = "r8g8b8";
+
+			clocks = <&gcc GCC_MDSS_AHB_CLK>,
+				 <&gcc GCC_MDSS_AXI_CLK>,
+				 <&gcc GCC_MDSS_VSYNC_CLK>,
+				 <&gcc GCC_MDSS_MDP_CLK>,
+				 <&gcc GCC_MDSS_BYTE0_CLK>,
+				 <&gcc GCC_MDSS_PCLK0_CLK>,
+				 <&gcc GCC_MDSS_ESC0_CLK>;
+			power-domains = <&gcc MDSS_GDSC>;
+		};
+	};
+
+	reserved-memory {
+		/delete-node/ reserved@85b00000;
+		qseecom_mem: qseecom@84a00000 {
+			reg = <0x0 0x84a00000 0x0 0x1900000>;
+			no-map;
+		};
+
+		cont_splash_mem: cont-splash@90001000 {
+			reg = <0x0 0x90001000 0x0 (720 * 1280 * 3)>;
+			no-map;
+		};
+
+		ramoops@b0000000 {
+		  compatible = "ramoops";
+		  reg = <0x00 0xb0000000 0x00 0x800000>;
+		  record-size = <0x200000>;
+		  console-size = <0x200000>;
+		  pmsg-size = <0x200000>;
+		};
+	};
+
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-min-microvolt = <3700000>;
+		regulator-max-microvolt = <3700000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		btn-volup {
+			label = "Volume Up";
+			linux,code = <KEY_VOLUMEUP>;
+			gpios = <&tlmm 91 GPIO_ACTIVE_LOW>;
+			debounce-interval = <15>;
+		};
+	};
+
+	usb_vbus: extcon-usb-dummy {
+		compatible = "linux,extcon-usb-dummy";
+	};
+};
+
+&adsp_mem {
+	status = "okay";
+};
+
+&blsp_i2c3 {
+	status = "okay";
+
+	touchscreen@5d {
+		compatible = "goodix,gt911";
+		reg = <0x5d>;
+
+		interrupt-parent = <&tlmm>;
+		interrupts = <65 IRQ_TYPE_EDGE_FALLING>;
+		irq-gpios = <&tlmm 65 0>;
+		reset-gpios = <&tlmm 64 0>;
+
+		AVDD28-supply = <&pm8937_l10>;
+		VDDIO-supply = <&pm8937_l6>;
+	};
+};
+
+&blsp_i2c5 {
+	status = "okay";
+
+	led-controller@45 {
+		compatible = "awinic,aw2013";
+		reg = <0x45>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+
+		vcc-supply = <&pm8937_l10>;
+		vio-supply = <&pm8937_l5>;
+
+		led@0 {
+			reg = <0>;
+			function = LED_FUNCTION_INDICATOR;
+			led-max-microamp = <5000>;
+			color = <LED_COLOR_ID_WHITE>;
+		};
+	};
+};
+
+&pm8937_resin {
+	linux,code = <KEY_VOLUMEDOWN>;
+	status = "okay";
+};
+
+&pm8937_spmi_regulators {
+	pm8937_s5: s5 {
+		regulator-min-microvolt = <1050000>;
+		regulator-max-microvolt = <1350000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+};
+
+&rpm_requests {
+	regulators-0 {
+		compatible = "qcom,rpm-pm8937-regulators";
+
+		vdd_s1-supply = <&vph_pwr>;
+		vdd_s2-supply = <&vph_pwr>;
+		vdd_s3-supply = <&vph_pwr>;
+		vdd_s4-supply = <&vph_pwr>;
+
+		vdd_l1_l19-supply = <&pm8937_s3>;
+		vdd_l2_l23-supply = <&pm8937_s3>;
+		vdd_l3-supply = <&pm8937_s3>;
+		vdd_l4_l5_l6_l7_l16-supply = <&pm8937_s4>;
+		vdd_l8_l11_l12_l17_l22-supply = <&vph_pwr>;
+		vdd_l9_l10_l13_l14_l15_l18-supply = <&vph_pwr>;
+
+		pm8937_s1: s1 {
+			regulator-min-microvolt = <1000000>;
+			regulator-max-microvolt = <1225000>;
+		};
+
+		pm8937_s3: s3 {
+			regulator-min-microvolt = <1300000>;
+			regulator-max-microvolt = <1300000>;
+		};
+
+		pm8937_s4: s4 {
+			regulator-min-microvolt = <2050000>;
+			regulator-max-microvolt = <2050000>;
+		};
+
+		pm8937_l2: l2 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+		};
+
+		pm8937_l5: l5 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8937_l6: l6 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8937_l7: l7 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8937_l8: l8 {
+			regulator-min-microvolt = <2850000>;
+			regulator-max-microvolt = <2900000>;
+		};
+
+		pm8937_l9: l9 {
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8937_l10: l10 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <3000000>;
+		};
+
+		pm8937_l11: l11 {
+			regulator-min-microvolt = <2950000>;
+			regulator-max-microvolt = <2950000>;
+		};
+
+		pm8937_l12: l12 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2950000>;
+		};
+
+		pm8937_l13: l13 {
+			regulator-min-microvolt = <3075000>;
+			regulator-max-microvolt = <3075000>;
+		};
+
+		pm8937_l14: l14 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8937_l15: l15 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8937_l16: l16 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8937_l17: l17 {
+			regulator-min-microvolt = <2850000>;
+			regulator-max-microvolt = <2900000>;
+		};
+
+		pm8937_l19: l19 {
+			regulator-min-microvolt = <1225000>;
+			regulator-max-microvolt = <1350000>;
+		};
+
+		pm8937_l22: l22 {
+			regulator-min-microvolt = <2850000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8937_l23: l23 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+		};
+	};
+};
+
+&sdhc_1 {
+	vmmc-supply = <&pm8937_l8>;
+	vqmmc-supply = <&pm8937_l5>;
+	status = "okay";
+};
+
+&sdhc_2 {
+	cd-gpios = <&tlmm 67 GPIO_ACTIVE_LOW>;
+	vmmc-supply = <&pm8937_l11>;
+	vqmmc-supply = <&pm8937_l12>;
+	status = "okay";
+};
+
+&tlmm {
+	gpio-reserved-ranges = <85 4>;
+};
+
+&usb {
+	dr_mode = "peripherial";
+	extcon = <&usb_vbus>;
+	interrupts = <GIC_SPI 134 IRQ_TYPE_LEVEL_HIGH>,
+		<GIC_SPI 140 IRQ_TYPE_LEVEL_HIGH>,
+		<GIC_SPI 136 IRQ_TYPE_LEVEL_HIGH>;
+	status = "okay";
+};
+
+&usb_hs_phy {
+	vdd-supply = <&pm8937_l2>;
+	vdda1p8-supply = <&pm8937_l7>;
+	vdda3p3-supply = <&pm8937_l13>;
+	status = "okay";
+};
+
+&venus_mem {
+	status = "okay";
+};
+
+&wcnss {
+	vddpx-supply = <&pm8937_l5>;
+	status = "okay";
+
+	iris {
+		compatible = "qcom,wcn3620";
+		vddxo-supply = <&pm8937_l7>;
+		vddrfa-supply = <&pm8937_l19>;
+		vddpa-supply = <&pm8937_l9>;
+		vdddig-supply = <&pm8937_l5>;
+	};
+};
+
+&wcnss_mem {
+	status = "okay";
+};

--- a/arch/arm64/boot/dts/qcom/msm8917.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8917.dtsi
@@ -555,7 +555,7 @@
 			      <0x004a8000 0x1000>;
 			nvmem-cells = <&tsens_caldata>;
 			nvmem-cell-names = "calib";
-			#qcom,sensors = <11>;
+			#qcom,sensors = <10>;
 			interrupts = <GIC_SPI 184 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-names = "uplow";
 			#thermal-sensor-cells = <1>;

--- a/drivers/extcon/Kconfig
+++ b/drivers/extcon/Kconfig
@@ -168,6 +168,13 @@ config EXTCON_SM5502
 	  Silicon Mitus SM5502. The SM5502 is a USB port accessory
 	  detector and switch.
 
+config EXTCON_USB_DUMMY
+	tristate "Dummy USB extcon support"
+	help
+	  Say Y here to create an extcon device that always reports USB=1
+	  and nothing else. This is stupid, but helpful as workaround for some
+	  funny implementation details for now. Just look away. Now! Still here?
+
 config EXTCON_USB_GPIO
 	tristate "USB GPIO extcon support"
 	depends on GPIOLIB || COMPILE_TEST

--- a/drivers/extcon/Makefile
+++ b/drivers/extcon/Makefile
@@ -22,6 +22,7 @@ obj-$(CONFIG_EXTCON_PTN5150)	+= extcon-ptn5150.o
 obj-$(CONFIG_EXTCON_QCOM_SPMI_MISC) += extcon-qcom-spmi-misc.o
 obj-$(CONFIG_EXTCON_RT8973A)	+= extcon-rt8973a.o
 obj-$(CONFIG_EXTCON_SM5502)	+= extcon-sm5502.o
+obj-$(CONFIG_EXTCON_USB_DUMMY)	+= extcon-usb-dummy.o
 obj-$(CONFIG_EXTCON_USB_GPIO)	+= extcon-usb-gpio.o
 obj-$(CONFIG_EXTCON_USBC_CROS_EC) += extcon-usbc-cros-ec.o
 obj-$(CONFIG_EXTCON_USBC_TUSB320) += extcon-usbc-tusb320.o

--- a/drivers/extcon/extcon-usb-dummy.c
+++ b/drivers/extcon/extcon-usb-dummy.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-2.0-only
+
+#include <linux/extcon-provider.h>
+#include <linux/module.h>
+#include <linux/of.h>
+#include <linux/platform_device.h>
+
+static const unsigned int extcon_dummy_cable[] = {
+	EXTCON_USB,
+	EXTCON_NONE,
+};
+
+static int extcon_dummy_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct extcon_dev *edev;
+	int ret;
+
+	edev = devm_extcon_dev_allocate(dev, extcon_dummy_cable);
+	if (IS_ERR(edev))
+		return PTR_ERR(edev);
+
+	ret = devm_extcon_dev_register(dev, edev);
+	if (ret < 0) {
+		dev_err(dev, "failed to register extcon device: %d\n", ret);
+		return ret;
+	}
+
+	/* Pretend that USB is always connected */
+	extcon_set_state_sync(edev, EXTCON_USB, true);
+
+	return 0;
+}
+
+static const struct of_device_id extcon_dummy_of_match[] = {
+	{ .compatible = "linux,extcon-usb-dummy", },
+	{ /* sentinel */ }
+};
+MODULE_DEVICE_TABLE(of, extcon_dummy_of_match);
+
+static struct platform_driver extcon_dummy_driver = {
+	.probe = extcon_dummy_probe,
+	.driver = {
+		.name = "extcon-usb-dummy",
+		.of_match_table = extcon_dummy_of_match,
+	},
+};
+module_platform_driver(extcon_dummy_driver);
+
+MODULE_DESCRIPTION("Dummy USB extcon driver");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Add initial support for Xiaomi Redmi Note 5A (ugglite).

What works:
- [x] Booting
- [x] EMMC
- [X] SD
- [x] Simple FB
- [X] Leds
- [X] USB
- [X] Wifi
- [X] Touch
...   