### PR TITLE
msm8917: fix cpuidle

### DIFF
--- a/Documentation/devicetree/bindings/arm/psci.yaml
+++ b/Documentation/devicetree/bindings/arm/psci.yaml
@@ -98,6 +98,13 @@ properties:
       [1] Kernel documentation - ARM idle states bindings
         Documentation/devicetree/bindings/cpu/idle-states.yaml
 
+  force-psci-domains:
+    $ref: /schemas/types.yaml#/definitions/flag
+    description: |
+      Force using PSCI power domains. This skips setting OSI mode because it's
+      already enabled by the firmware and cannot be changed.
+      Relevant for some legacy Qualcomm SoCs.
+
 patternProperties:
   "^power-domain-":
     $ref: /schemas/power/power-domain.yaml#

--- a/arch/arm64/boot/dts/qcom/msm8917.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8917.dtsi
@@ -113,12 +113,27 @@
 		};
 
 		domain-idle-states {
-			cluster_sleep_0: cluster-sleep-0 {
+			/* Seems strange, but downstream msm8917-pm.dtsi specifies
+			   GHDS as faster than retention, unlike for other SoCs */
+
+			cluster_gdhs: cluster-gdhs {
 				compatible = "domain-idle-state";
-				arm,psci-suspend-param = <0x41000053>;
-				entry-latency-us = <700>;
-				exit-latency-us = <1000>;
-				min-residency-us = <6500>;
+				idle-state-name = "cluster-gdhs";
+				arm,psci-suspend-param = <0x41000043>;
+				entry-latency-us = <150>;
+				exit-latency-us = <280>;
+				min-residency-us = <560>;
+				local-timer-stop;
+			};
+
+			cluster_ret: cluster-retention {
+				compatible = "domain-idle-state";
+				idle-state-name = "cluster-ret";
+				arm,psci-suspend-param = <0x41000033>;
+				entry-latency-us = <120>;
+				exit-latency-us = <650>;
+				min-residency-us = <1300>;
+				local-timer-stop;
 			};
 		};
 
@@ -185,10 +200,11 @@
 	psci {
 		compatible = "arm,psci-1.0";
 		method = "smc";
+		force-psci-domains;
 
 		cluster_pd: power-domain-cluster {
 			#power-domain-cells = <0>;
-			domain-idle-states = <&cluster_sleep_0>;
+			domain-idle-states = <&cluster_gdhs>, <&cluster_ret>;
 		};
 
 		cpu_pd0: power-domain-cpu0 {

--- a/drivers/cpuidle/cpuidle-psci-domain.c
+++ b/drivers/cpuidle/cpuidle-psci-domain.c
@@ -143,10 +143,12 @@ static int psci_cpuidle_domain_probe(struct platform_device *pdev)
 {
 	struct device_node *np = pdev->dev.of_node;
 	bool use_osi = psci_has_osi_support();
+	bool force_psci_domains;
 	int ret = 0, pd_count = 0;
 
 	if (!np)
 		return -ENODEV;
+
 
 	/*
 	 * Parse child nodes for the "#power-domain-cells" property and
@@ -172,13 +174,18 @@ static int psci_cpuidle_domain_probe(struct platform_device *pdev)
 	if (ret)
 		goto remove_pd;
 
-	/* let's try to enable OSI. */
-	ret = psci_set_osi_mode(use_osi);
-	if (ret)
-		goto remove_pd;
+	force_psci_domains = of_property_read_bool(np, "force-psci-domains");
 
-	pr_info("Initialized CPU PM domain topology using %s mode\n",
-		use_osi ? "OSI" : "PC");
+	if (!force_psci_domains) {
+		/* let's try to enable OSI. */
+		ret = psci_set_osi_mode(use_osi);
+		if (ret)
+			goto remove_pd;
+
+		pr_info("Initialized CPU PM domain topology using %s mode\n",
+			use_osi ? "OSI" : "PC");
+	}
+
 	return 0;
 
 remove_pd:


### PR DESCRIPTION
Would need a similar (but not identical — cluster power collapse would be fine since it's multi-cluster) commit for msm8937 but I don't have one to test so only including 8917 changes here.

Downstream ref: https://github.com/motoe5/android_kernel_motorola_msm8937/blob/b7208334649ddee80cf1cdc8cf233d481509199f/arch/arm/boot/dts/qcom/msm8917-pm.dtsi#L64-L86