### PR TITLE
squash! arm64: dts: qcom: msm8917: fix cpu idle states

### DIFF
--- a/arch/arm64/boot/dts/qcom/msm8917.dtsi
+++ b/arch/arm64/boot/dts/qcom/msm8917.dtsi
@@ -113,26 +113,13 @@
 		};
 
 		domain-idle-states {
-			/* Seems strange, but downstream msm8917-pm.dtsi specifies
-			   GHDS as faster than retention, unlike for other SoCs */
-
-			cluster_gdhs: cluster-gdhs {
+			cluster_pwrdn: cluster-sleep-0 {
 				compatible = "domain-idle-state";
-				idle-state-name = "cluster-gdhs";
+				idle-state-name = "cluster-sleep-0";
 				arm,psci-suspend-param = <0x41000043>;
-				entry-latency-us = <150>;
+				entry-latency-us = <240>;
 				exit-latency-us = <280>;
-				min-residency-us = <560>;
-				local-timer-stop;
-			};
-
-			cluster_ret: cluster-retention {
-				compatible = "domain-idle-state";
-				idle-state-name = "cluster-ret";
-				arm,psci-suspend-param = <0x41000033>;
-				entry-latency-us = <120>;
-				exit-latency-us = <650>;
-				min-residency-us = <1300>;
+				min-residency-us = <6000>;
 				local-timer-stop;
 			};
 		};
@@ -146,7 +133,7 @@
 				arm,psci-suspend-param = <0x40000003>;
 				entry-latency-us = <125>;
 				exit-latency-us = <180>;
-				min-residency-us = <595>;
+				min-residency-us = <2000>;
 				local-timer-stop;
 			};
 		};
@@ -204,7 +191,7 @@
 
 		cluster_pd: power-domain-cluster {
 			#power-domain-cells = <0>;
-			domain-idle-states = <&cluster_gdhs>, <&cluster_ret>;
+			domain-idle-states = <&cluster_pwrdn>;
 		};
 
 		cpu_pd0: power-domain-cpu0 {


### PR DESCRIPTION
pwrdn/ghds (4) is the only cluster state we can use. retention (2) seems broken (hangs), looks like that's why it was marked as worse than ghds in the downstream dts.

---

oops, the bogus `0x41000033` state was actually making everything worse.

Battery discharge rate on nora with display off:

- baseline: ~0.69 (nice)
- cpu-pc only: ~0.59
- bogus cluster state 3: ~0.90
- cluster-pwrdn: ~0.52