### PR TITLE
Enable PMIC ATC LEDs

### DIFF
--- a/Documentation/devicetree/bindings/leds/leds-atc.txt
+++ b/Documentation/devicetree/bindings/leds/leds-atc.txt
@@ -1,0 +1,14 @@
+Driver leds-atc is used to control ATC charging led on a Qualcomm PMIC.
+
+Required properties
+ - compatible	: string should be "qcom,leds-atc"
+ - reg		: The register address + control address. Check PMIC specification.
+ - label	: name of the led that is used in the led framework
+
+Example:
+
+leds@1000 {
+	compatible = "qcom,leds-atc";
+	reg = <0x1243>; //0x1000 + 0x243
+	label = "charging";
+};

--- a/arch/arm64/boot/dts/qcom/msm8917-motorola-nora.dts
+++ b/arch/arm64/boot/dts/qcom/msm8917-motorola-nora.dts
@@ -247,6 +247,10 @@
 	};
 };
 
+&pmi8950_atc_leds {
+	status = "okay";
+};
+
 &pmi8950_fg {
 	monitored-battery = <&battery>;
 	power-supplies = <&pmi8950_smbcharger>;

--- a/arch/arm64/boot/dts/qcom/pmi8950.dtsi
+++ b/arch/arm64/boot/dts/qcom/pmi8950.dtsi
@@ -94,6 +94,14 @@
 			status = "disabled";
 		};
 
+		pmi8950_atc_leds: leds@1243 {
+			compatible = "qcom,leds-atc";
+			reg = <0x1243>;
+			label = "charging";
+
+			status = "disabled";
+		};
+
 		pmi8950_usb_vbus: usb-detect@1300 {
 			compatible = "qcom,pm8941-misc";
 			reg = <0x1300>;

--- a/drivers/leds/Kconfig
+++ b/drivers/leds/Kconfig
@@ -128,6 +128,15 @@ config LEDS_AW2013
 	  To compile this driver as a module, choose M here: the module
 	  will be called leds-aw2013.
 
+config LEDS_ATC
+	tristate "Qualcomm PMIC ATC LED Support"
+	depends on LEDS_CLASS
+	depends on SPMI || COMPILE_TEST
+	depends on OF
+	help
+	  This option enabled support for Advanced Tickle Charge (ATC) LEDs
+	  present on some Qualcomm PMICs
+
 config LEDS_BCM6328
 	tristate "LED Support for Broadcom BCM6328"
 	depends on LEDS_CLASS

--- a/drivers/leds/Makefile
+++ b/drivers/leds/Makefile
@@ -16,6 +16,7 @@ obj-$(CONFIG_LEDS_APU)			+= leds-apu.o
 obj-$(CONFIG_LEDS_ARIEL)		+= leds-ariel.o
 obj-$(CONFIG_LEDS_AW200XX)		+= leds-aw200xx.o
 obj-$(CONFIG_LEDS_AW2013)		+= leds-aw2013.o
+obj-$(CONFIG_LEDS_ATC)			+= leds-atc.o
 obj-$(CONFIG_LEDS_BCM6328)		+= leds-bcm6328.o
 obj-$(CONFIG_LEDS_BCM6358)		+= leds-bcm6358.o
 obj-$(CONFIG_LEDS_BD2606MVV)		+= leds-bd2606mvv.o

--- a/drivers/leds/leds-atc.c
+++ b/drivers/leds/leds-atc.c
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-2.0-only
+// Copyright (c) 2020, The Linux Foundation. All rights reserved.
+
+#include <linux/delay.h>
+#include <linux/module.h>
+#include <linux/leds.h>
+#include <linux/platform_device.h>
+#include <linux/regmap.h>
+#include <linux/of_address.h>
+#include <linux/of_device.h>
+
+#define ATC_LED_CFG_SHIFT	1
+#define ATC_LED_CFG_MASK	0x06
+#define ATC_LED_ON		0x03
+#define ATC_LED_OFF		0x00
+
+struct atc_led_data {
+	struct led_classdev cdev;
+	struct device *dev;
+	struct regmap *regmap;
+	u32 addr;
+};
+
+static int atc_led_reg_masked_write(struct atc_led_data *led, u16 addr,
+		u8 mask, u8 val)
+{
+	u8 reg;
+	int error;
+
+	error = regmap_raw_read(led->regmap, addr, &reg, 1);
+	if (error)
+		return error;
+	reg &= ~mask;
+	reg |= val;
+
+	error = regmap_raw_write(led->regmap, addr, &reg, 1);
+
+	return error;
+}
+
+static void atc_led_set(struct led_classdev *cdev, enum led_brightness value)
+{
+	struct platform_device *pdev = to_platform_device(cdev->dev->parent);
+	struct atc_led_data *led = dev_get_drvdata(&pdev->dev);
+	u8 brightness;
+	int error;
+
+	if (value > ATC_LED_ON)
+		value = ATC_LED_ON;
+
+	brightness = value << ATC_LED_CFG_SHIFT;
+	error = atc_led_reg_masked_write(led, led->addr, ATC_LED_CFG_MASK, brightness);
+	if (error)
+		dev_err(led->dev, "Failed to set brightnes, addr = %d\n", led->addr);
+}
+
+static enum led_brightness atc_led_get(struct led_classdev *cdev)
+{
+	return cdev->brightness;
+}
+
+static int atc_led_probe(struct platform_device *pdev)
+{
+	struct atc_led_data *led;
+	struct regmap *regmap;
+	const __be32 *prop_addr;
+	u8 reg;
+	int error;
+
+	regmap = dev_get_regmap(pdev->dev.parent, NULL);
+	if (!regmap) {
+		dev_err(&pdev->dev, "Unable to get regmap\n");
+		return -EINVAL;
+	}
+
+	led = devm_kzalloc(&pdev->dev, sizeof(*led), GFP_KERNEL);
+	if (!led)
+		return -ENOMEM;
+
+	led->regmap = regmap;
+	led->dev = &pdev->dev;
+
+	prop_addr = of_get_address(pdev->dev.of_node, 0, NULL, NULL);
+	if (!prop_addr) {
+		dev_err(&pdev->dev, "invalid IO resource\n");
+		return -EINVAL;
+	}
+	led->addr = be32_to_cpu(*prop_addr);
+
+	error = of_property_read_string(pdev->dev.of_node, "label", &led->cdev.name);
+	if (error)
+		led->cdev.name = devm_kasprintf(led->dev, GFP_KERNEL, "%pATC",
+				led->dev->of_node);
+
+	error = regmap_raw_read(led->regmap, led->addr, &reg, 1);
+
+	led->cdev.brightness_set = atc_led_set;
+	led->cdev.brightness_get = atc_led_get;
+	led->cdev.brightness = (reg & ATC_LED_CFG_MASK) >> ATC_LED_CFG_SHIFT;
+	led->cdev.max_brightness = ATC_LED_ON;
+
+	error = led_classdev_register(led->dev, &led->cdev);
+	if (error) {
+		dev_err(led->dev, "unable to register ATC led, error = %d\n",
+				error);
+		return error;
+	}
+
+	platform_set_drvdata(pdev, led);
+	return 0;
+}
+
+static void atc_led_remove(struct platform_device *pdev)
+{
+	struct atc_led_data *led = dev_get_drvdata(&pdev->dev);
+	if (led != NULL)
+		led_classdev_unregister(&led->cdev);
+}
+
+static struct of_device_id atc_led_match_table[] = {
+	{ .compatible = "qcom,leds-atc", },
+	{ },
+};
+
+static struct platform_driver atc_leds_driver = {
+	.probe = atc_led_probe,
+	.remove = atc_led_remove,
+	.driver = {
+		.name = "qcom,leds-atc",
+		.of_match_table = atc_led_match_table,
+	},
+};
+
+module_platform_driver(atc_leds_driver);
+
+MODULE_DESCRIPTION("Qualcomm ATC-LED driver");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Gotta find out why the driver wasn't upstreamed yet, and if we're going to be the ones to upstream it, rewrite the binding as yaml instead of text