### PR TITLE
arm64: dts: qcom: Add SDM429

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -230,6 +230,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= sc8280xp-lenovo-thinkpad-x13s.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sc8280xp-microsoft-arcata.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sc8280xp-microsoft-blackrock.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sda660-inforce-ifc6560.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= sdm429w-fossil-hoki.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm439-xiaomi-pine.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm450-lenovo-tbx605f.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm450-motorola-ali.dtb

--- a/arch/arm64/boot/dts/qcom/sdm429.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdm429.dtsi
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025, Simon Sommer <misom@symlinks.dev>
+ */
+#include "sdm439.dtsi"
+
+/delete-node/ &pll_opp_table_c1;
+/delete-node/ &cpu_opp_table_c1;
+
+/ {
+	cpu_opp_table_c1: opp-table-c1 {
+		compatible = "operating-points-v2";
+		opp-shared;
+
+		opp-960000000 {
+			opp-hz = /bits/ 64 <960000000>;
+		};
+
+		opp-1305600000 {
+			opp-hz = /bits/ 64 <1305600000>;
+		};
+
+		opp-1497600000 {
+			opp-hz = /bits/ 64 <1497600000>;
+		};
+
+		opp-1708800000 {
+			opp-hz = /bits/ 64 <1708800000>;
+		};
+
+		opp-1804800000 {
+			opp-hz = /bits/ 64 <1804800000>;
+		};
+
+		opp-1958400000 {
+			opp-hz = /bits/ 64 <1958400000>;
+		};
+
+		opp-2016000000 {
+			opp-hz = /bits/ 64 <2016000000>;
+		};
+	};
+};
+
+&a53pll_c1 {
+	operating-points-v2 = <&pll_opp_table_c1>;
+	pll_opp_table_c1: opp-table {
+		compatible = "operating-points-v2";
+
+		opp-960000000 {
+			opp-hz = /bits/ 64 <960000000>;
+		};
+
+		opp-1305600000 {
+			opp-hz = /bits/ 64 <1305600000>;
+		};
+
+		opp-1497600000 {
+			opp-hz = /bits/ 64 <1497600000>;
+		};
+
+		opp-1708800000 {
+			opp-hz = /bits/ 64 <1708800000>;
+		};
+
+		opp-1804800000 {
+			opp-hz = /bits/ 64 <1804800000>;
+		};
+
+		opp-1958400000 {
+			opp-hz = /bits/ 64 <1958400000>;
+		};
+
+		opp-2016000000 {
+			opp-hz = /bits/ 64 <2016000000>;
+		};
+	};
+};
+
+&adreno_smmu {
+	/delete-node/ iommu-ctx@2000; // gfx3d_secure
+};
+
+&apcs0 {
+	status = "disabled";
+};
+
+&soc {
+	blsp2_uart2: serial@7af0000 {
+		compatible = "qcom,msm-uartdm-v1.4", "qcom,msm-uartdm";
+		reg = <0x07af0000 0x200>;
+
+		interrupts = <GIC_SPI 307 IRQ_TYPE_LEVEL_HIGH>;
+
+		clocks = <&gcc GCC_BLSP2_UART2_APPS_CLK>, <&gcc GCC_BLSP2_AHB_CLK>;
+		clock-names = "core", "iface";
+
+		dmas = <&blsp2_dma 2>, <&blsp2_dma 3>;
+		dma-names = "tx", "rx";
+
+		pinctrl-names = "default", "sleep";
+		pinctrl-0 = <&blsp2_uart2_default>;
+		pinctrl-1 = <&blsp2_uart2_sleep>;
+
+		status = "disabled";
+	};
+};
+
+&thermal_zones {
+	/delete-node/ cpuss0-thermal;
+};

--- a/arch/arm64/boot/dts/qcom/sdm429w-fossil-hoki.dts
+++ b/arch/arm64/boot/dts/qcom/sdm429w-fossil-hoki.dts
@@ -1,0 +1,418 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025, Simon Sommer <misom@symlinks.dev>
+ */
+/dts-v1/;
+#include <dt-bindings/arm/qcom,ids.h>
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/input/qcom,spmi-haptics.h>
+#include "sdm429.dtsi"
+#include "pm660.dtsi"
+
+/ {
+	interrupt-parent = <&intc>;
+	#address-cells = <2>;
+	#size-cells = <2>;
+
+	model = "Fossil Gen 6";
+	compatible = "fossil,hoki", "qcom,sdm429w";
+	qcom,msm-id = <QCOM_ID_SDA429W 0>;
+	qcom,board-id = <0x10b 0x0a>;
+
+	aliases {
+		mmc1 = &sdhc_1;
+	};
+
+	battery: battery {
+		compatible = "simple-battery";
+		device-chemistry = "lithium-ion-polymer";
+
+		constant-charge-current-max-microamp = <300000>;
+
+		charge-full-design-microamp-hours = <300000>;
+		voltage-min-design-microvolt = <3400000>;
+		voltage-max-design-microvolt = <4450000>;
+	};
+
+	chosen {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		stdout-path = "framebuffer0";
+
+		framebuffer0: framebuffer@90001000 {
+			compatible = "simple-framebuffer";
+			reg = <0x0 0x90001000 0x0 (416 * 416 * 3)>;
+			width = <416>;
+			height = <416>;
+			stride = <(416 * 3)>;
+			format = "r8g8b8";
+
+			clocks = <&gcc GCC_MDSS_AHB_CLK>,
+				 <&gcc GCC_MDSS_AXI_CLK>,
+				 <&gcc GCC_MDSS_VSYNC_CLK>,
+				 <&gcc GCC_MDSS_MDP_CLK>,
+				 <&gcc GCC_MDSS_BYTE0_CLK>,
+				 <&gcc GCC_MDSS_PCLK0_CLK>,
+				 <&gcc GCC_MDSS_ESC0_CLK>;
+			power-domains = <&gcc MDSS_GDSC>;
+		};
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-names = "default";
+
+		key-volup {
+			label = "Volume Up";
+			linux,code = <KEY_VOLUMEUP>;
+			gpios = <&tlmm 35 GPIO_ACTIVE_LOW>;
+			debounce-interval = <15>;
+		};
+	};
+
+	reserved-memory {
+		framebuffer_mem: memory@90001000 {
+			reg = <0x0 0x90001000 0x0 (416 * 416 * 3)>;
+			no-map;
+		};
+	};
+
+	usb_vbus: extcon-usb-dummy {
+		compatible = "linux,extcon-usb-dummy";
+	};
+
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-min-microvolt = <3700000>;
+		regulator-max-microvolt = <3700000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+};
+
+&spmi_bus {
+	pmic@0 {
+		pm660_fg: fuel-gauge@4000 {
+			compatible = "qcom,pmi8998-fg";
+			reg = <0x4000>;
+
+			interrupts = <0x0 0x40 0x2 IRQ_TYPE_EDGE_RISING>;
+			interrupt-names = "soc-delta";
+
+			status = "disabled";
+		};
+	};
+	pmic@1 {
+		pm660_haptics: vibrator@c000 {
+			compatible = "qcom,pmi8998-haptics", "qcom,spmi-haptics";
+			reg = <0xc000>;
+
+			interrupts = <0x1 0xc0 0x0 IRQ_TYPE_EDGE_BOTH>,
+					 <0x1 0xc0 0x1 IRQ_TYPE_EDGE_BOTH>;
+			interrupt-names = "short", "play";
+
+			status = "disabled";
+		};
+	};
+};
+
+&adsp {
+	status = "okay";
+};
+
+&adsp_mem {
+	size = <0x0 0x1800000>;
+	status = "okay";
+};
+
+&blsp1_uart2 {
+	// DMA seems to cause issues when sending a lot of data at once
+	/delete-property/ dmas;
+	/delete-property/ dma-names;
+	status = "okay";
+};
+
+&blsp2_uart2 {
+	status = "okay";
+
+	bluetooth {
+		compatible = "qcom,wcn3988-bt";
+
+		vddio-supply = <&pm660_l13>;
+		max-speed = <3200000>;
+
+		pinctrl-0 = <&bt_enable_default>;
+		pinctrl-names = "default";
+		status = "okay";
+	};
+};
+
+&pm660_adc {
+	status = "okay";
+};
+
+&pm660_charger {
+	monitored-battery = <&battery>;
+
+	status = "okay";
+};
+
+&pm660_fg {
+	monitored-battery = <&battery>;
+	power-supplies = <&pm660_charger>;
+
+	status = "okay";
+};
+
+&pm660_haptics {
+	qcom,actuator-type = <HAP_TYPE_ERM>;
+	qcom,brake-pattern = <0x3 0x3 0x0 0x0>;
+
+	qcom,vmax-millivolt = <3200>;
+
+	qcom,wave-play-rate-us = <10000>;
+	qcom,wave-shape = <HAP_WAVE_SQUARE>;
+
+	status = "okay";
+};
+
+&pm660_rradc {
+	status = "okay";
+};
+
+&pon {
+	status = "okay";
+};
+
+&pon_pwrkey {
+	status = "okay";
+};
+
+&pon_resin {
+	linux,code = <KEY_VOLUMEDOWN>;
+	status = "okay";
+};
+
+&rpm_requests {
+	regulators-0 {
+		compatible = "qcom,rpm-pm660-regulators";
+
+		vdd_s1-supply = <&vph_pwr>;
+		vdd_s2-supply = <&vph_pwr>;
+		vdd_s3-supply = <&vph_pwr>;
+		vdd_s4-supply = <&vph_pwr>;
+		vdd_s5-supply = <&vph_pwr>;
+		vdd_s6-supply = <&vph_pwr>;
+
+		/*
+		 * S1A (FTAPC0), S2A (FTAPC1), S3A (HFAPC1) are managed
+		 * by the Core Power Reduction hardened (CPRh) and the
+		 * Operating State Manager (OSM) HW automatically.
+		 */
+
+		pm660_s4: s4 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <200>;
+			regulator-ramp-delay = <0>;
+			regulator-always-on;
+		};
+
+		pm660_s5: s5 {
+			regulator-min-microvolt = <1040000>;
+			regulator-max-microvolt = <1420000>;
+			regulator-enable-ramp-delay = <200>;
+			regulator-ramp-delay = <0>;
+		};
+
+		/* LDOs */
+		pm660_l1: l1 {
+			regulator-min-microvolt = <970000>;
+			regulator-max-microvolt = <1280000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+			regulator-allow-set-load;
+		};
+
+		pm660_l3: l3 {
+			regulator-min-microvolt = <900000>;
+			regulator-max-microvolt = <1280000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l5: l5 {
+			regulator-min-microvolt = <1150000>;
+			regulator-max-microvolt = <1450000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l6: l6 {
+			regulator-min-microvolt = <670000>;
+			regulator-max-microvolt = <930000>;
+			regulator-allow-set-load;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l7: l7 {
+			regulator-min-microvolt = <1140000>;
+			regulator-max-microvolt = <1280000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l8: l8 {
+			regulator-min-microvolt = <1500000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+			regulator-system-load = <325000>;
+			regulator-allow-set-load;
+		};
+
+		pm660_l9: l9 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+			regulator-allow-set-load;
+		};
+
+		pm660_l10: l10 {
+			regulator-min-microvolt = <500000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+			regulator-allow-set-load;
+		};
+
+		pm660_l11: l11 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l12: l12 {
+			regulator-min-microvolt = <1620000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		/* This gives power to the MMC: never turn it off! */
+		pm660_l13: l13 {
+			regulator-min-microvolt = <1600000>;
+			regulator-max-microvolt = <2040000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+			regulator-boot-on;
+			regulator-always-on;
+		};
+
+		pm660_l15: l15 {
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3400000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l16: l16 {
+			regulator-min-microvolt = <2970000>;
+			regulator-max-microvolt = <3400000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+		};
+
+		pm660_l19: l19 {
+			regulator-min-microvolt = <2700000>;
+			regulator-max-microvolt = <3400000>;
+			regulator-enable-ramp-delay = <250>;
+			regulator-ramp-delay = <0>;
+			regulator-allow-set-load;
+			regulator-boot-on;
+			regulator-always-on;
+		};
+	};
+};
+
+&sdhc_1 {
+	vmmc-supply = <&pm660_l19>;
+	vqmmc-supply = <&pm660_l13>;
+	status = "okay";
+};
+
+&sleep_clk {
+	clock-frequency = <32768>;
+};
+
+&tlmm {
+	bt_enable_default: bt-enable-default-state {
+		pins = "gpio57", "gpio47";
+		function = "gpio";
+		drive-strength = <8>;
+		output-high;
+	};
+
+	blsp2_uart2_default: blsp2-uart2-default-state {
+		pins = "gpio20", "gpio21", "gpio22", "gpio23";
+		function = "blsp_uart6";
+		drive-strength = <4>;
+		bias-disable;
+	};
+
+	blsp2_uart2_sleep: blsp2-uart2-sleep-state {
+		pins = "gpio20", "gpio21", "gpio22", "gpio23";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+
+	gpio_keys_default: gpio-keys-default-state {
+		pins = "gpio35";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+};
+
+&usb {
+	dr_mode = "peripheral";
+	extcon = <&usb_vbus>;
+	status = "okay";
+};
+
+&usb_hs_phy {
+	vdd-supply = <&pm660_l6>;
+	vdda1p8-supply = <&pm660_l12>;
+	vdda3p3-supply = <&pm660_l16>;
+	status = "okay";
+};
+
+&wcnss {
+	vddpx-supply = <&pm660_l13>;
+	status = "okay";
+};
+
+&wcnss_iris {
+	compatible = "qcom,wcn3620";
+	vddxo-supply = <&pm660_l12>;
+	vddrfa-supply = <&pm660_l5>;
+	vdddig-supply = <&pm660_l13>;
+	status = "okay";
+};
+
+&wcnss_mem {
+	status = "okay";
+};
+
+&xo_board {
+	clock-frequency = <19200000>;
+};


### PR DESCRIPTION
Add initial support for SDM429 and Fossil Gen 6 (`hoki`), a device based on it.