### PR TITLE
Fix nokia-weeknd boot issues

### DIFF
--- a/arch/arm64/boot/dts/qcom/pm8916.dtsi
+++ b/arch/arm64/boot/dts/qcom/pm8916.dtsi
@@ -223,9 +223,6 @@
 		pm8916_codec: audio-codec@f000 {
 			compatible = "qcom,pm8916-wcd-analog-codec";
 			reg = <0xf000>;
-			reg-names = "pmic-codec-core";
-			clocks = <&xo_board>;
-			clock-names = "mclk";
 			interrupt-parent = <&spmi_bus>;
 			interrupts = <0x1 0xf0 0x0 IRQ_TYPE_NONE>,
 				     <0x1 0xf0 0x1 IRQ_TYPE_NONE>,

--- a/arch/arm64/boot/dts/qcom/qm215-nokia-weeknd.dts
+++ b/arch/arm64/boot/dts/qcom/qm215-nokia-weeknd.dts
@@ -298,6 +298,10 @@
 	};
 };
 
+&blsp1_uart2 {
+	status = "okay";
+};
+
 &camss {
 	status = "okay";
 	ports {
@@ -374,8 +378,8 @@
 };
 
 &pm8916_charger {
-	qcom,vdd-safe = <4250000>;
-	qcom,ibat-safe = <360000>;
+	qcom,fast-charge-safe-current = <360000>;
+	qcom,fast-charge-safe-voltage = <4250000>;
 
 	monitored-battery = <&bat>;
 
@@ -563,7 +567,7 @@
 };
 
 &usb_hs_phy {
-	extcon = <&pm8916_charger>;
+	status = "okay";
 };
 
 &wcnss {

--- a/arch/arm64/boot/dts/qcom/qm215.dtsi
+++ b/arch/arm64/boot/dts/qcom/qm215.dtsi
@@ -2,6 +2,13 @@
 
 #include "msm8917.dtsi"
 
+&modem {
+	compatible = "qcom,qm215-mss-pil", "qcom,mdm9607-mss-pil";
+
+	power-domains = <&rpmpd QM215_VDDCX>, <&rpmpd QM215_VDDMX>;
+	power-domain-names = "cx", "mx";
+};
+
 &gcc {
 	compatible = "qcom,gcc-qm215";
 	clocks = <&xo_board>,


### PR DESCRIPTION
Some parts of the qm215 and nokia-weeknd device trees are out of date. Adapt them to work with the current msm8917 device tree.