### PR TITLE
arm64: dts: qcom: sdm439: Add Xiaomi Redmi 8

### DIFF
--- a/arch/arm64/boot/dts/qcom/Makefile
+++ b/arch/arm64/boot/dts/qcom/Makefile
@@ -251,6 +251,7 @@ dtb-$(CONFIG_ARCH_QCOM)	+= sdm429-lenovo-tbx505x.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm429w-fossil-hoki.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm429w-mobvoi-rover.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm439-nokia-panther.dtb
+dtb-$(CONFIG_ARCH_QCOM)	+= sdm439-xiaomi-olive.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm439-xiaomi-pine.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm450-lenovo-tbx605f.dtb
 dtb-$(CONFIG_ARCH_QCOM)	+= sdm450-motorola-ali.dtb

--- a/arch/arm64/boot/dts/qcom/sdm439-xiaomi-olive.dts
+++ b/arch/arm64/boot/dts/qcom/sdm439-xiaomi-olive.dts
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2025, Barnabas Czeman <barnabas.czeman@mainlining.org>
+ * Copyright (c) 2026, Vladislav Agarkov <lavacat@disroot.org>
+ */
+/dts-v1/;
+
+#include <dt-bindings/arm/qcom,ids.h>
+#include <dt-bindings/gpio/gpio.h>
+#include "sdm439.dtsi"
+#include "pm8953.dtsi"
+#include "pmi632.dtsi"
+
+/delete-node/ &qseecom_mem;
+
+/ {
+	model = "Xiaomi Redmi 8 (olive)";
+	compatible = "xiaomi,olive", "qcom,sdm439";
+	chassis-type = "handset";
+
+	qcom,msm-id = <QCOM_ID_SDM439 0>;
+	qcom,board-id = <QCOM_BOARD_ID_QRD 8>;
+
+	chosen {
+		#address-cells = <2>;
+		#size-cells = <2>;
+		ranges;
+
+		stdout-path = "framebuffer0";
+
+		framebuffer0: framebuffer@90001000 {
+			compatible = "simple-framebuffer";
+			reg = <0x0 0x90001000 0x0 (720 * 1520 * 3)>;
+			width = <720>;
+			height = <1520>;
+			stride = <(720 * 3)>;
+			format = "r8g8b8";
+
+			clocks = <&gcc GCC_MDSS_AHB_CLK>,
+				 <&gcc GCC_MDSS_AXI_CLK>,
+				 <&gcc GCC_MDSS_VSYNC_CLK>,
+				 <&gcc GCC_MDSS_MDP_CLK>,
+				 <&gcc GCC_MDSS_BYTE0_CLK>,
+				 <&gcc GCC_MDSS_PCLK0_CLK>,
+				 <&gcc GCC_MDSS_ESC0_CLK>;
+			power-domains = <&gcc MDSS_GDSC>;
+		};
+	};
+
+	usb_vbus: extcon-usb-dummy {
+		compatible = "linux,extcon-usb-dummy";
+	};
+
+	gpio-keys {
+		compatible = "gpio-keys";
+
+		pinctrl-0 = <&gpio_keys_default>;
+		pinctrl-names = "default";
+
+		key-volup {
+			label = "Volume Up";
+			linux,code = <KEY_VOLUMEUP>;
+			gpios = <&tlmm 91 GPIO_ACTIVE_LOW>;
+			debounce-interval = <15>;
+		};
+	};
+
+	reserved-memory {
+		qseecom_mem: qseecom@84a00000 {
+			reg = <0x0 0x84a00000 0x0 0x1900000>;
+			no-map;
+		};
+
+		framebuffer_mem: memory@90001000 {
+			reg = <0x0 0x90001000 0x0 (720 * 1520 * 3)>;
+			no-map;
+		};
+	};
+
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-min-microvolt = <3700000>;
+		regulator-max-microvolt = <3700000>;
+		regulator-always-on;
+		regulator-boot-on;
+	};
+};
+
+&adsp {
+	status = "okay";
+};
+
+&adsp_mem {
+	size = <0x0 0x1800000>;
+	status = "okay";
+};
+
+&blsp1_uart2 {
+	status = "okay";
+};
+
+&blsp1_spi3 {
+	status = "disabled";
+
+	/* ilitek,ili9881h@0 */
+	/* novatek,nt36525b@1 */
+	/* focaltech,ft8006s@2 */
+};
+
+&blsp2_spi2 {
+	status = "okay";
+
+	irled@0 {
+		compatible = "ir-spi-led";
+		reg = <0>;
+		power-supply = <&pm8953_l8>;
+		spi-max-frequency = <19200000>;
+	};
+};
+
+&blsp2_i2c1 {
+	status = "disabled";
+	
+	lm3697@36 {
+		compatible = "ti,lm3697";
+		reg = <0x36>;
+		#address-cells = <1>;
+		#size-cells = <0>;
+		enable-gpios = <&pm8953_gpios 4 GPIO_ACTIVE_HIGH>;
+		status = "disabled";
+
+		lm3697_leds: led@0 {
+			reg = <0>;
+			led-sources = <0 1 2>;
+			ti,brightness-resolution = <255>;
+			ramp-up-us = <200000>;
+			ramp-down-us = <200000>;
+			label = "white:backlight";
+			linux,default-trigger = "backlight";
+		};
+	};
+
+	/* ktd3137@36 */
+};
+
+&pmi632_vib {
+	status = "okay";
+};
+
+&pm8953_resin {
+	linux,code = <KEY_VOLUMEDOWN>;
+	status = "okay";
+};
+
+&rpm_requests {
+	regulators {
+		compatible = "qcom,rpm-pm8953-regulators";
+
+		vdd_s1-supply = <&vph_pwr>;
+		vdd_s2-supply = <&vph_pwr>;
+		vdd_s3-supply = <&vph_pwr>;
+		vdd_s4-supply = <&vph_pwr>;
+		vdd_s5-supply = <&vph_pwr>;
+		vdd_s6-supply = <&vph_pwr>;
+		vdd_s7-supply = <&vph_pwr>;
+		vdd_l1-supply = <&pm8953_s3>;
+		vdd_l2_l3-supply = <&pm8953_s3>;
+		vdd_l4_l5_l6_l7_l16_l19-supply = <&pm8953_s4>;
+		vdd_l8_l11_l12_l13_l14_l15-supply = <&vph_pwr>;
+		vdd_l9_l10_l17_l18_l22-supply = <&vph_pwr>;
+		vdd_l23-supply = <&pm8953_s3>;
+
+		pm8953_s3: s3 {
+			regulator-min-microvolt = <856000>;
+			regulator-max-microvolt = <1280000>;
+		};
+
+		pm8953_s4: s4 {
+			regulator-min-microvolt = <1900000>;
+			regulator-max-microvolt = <2040000>;
+		};
+
+		pm8953_s5: s5 {
+			regulator-min-microvolt = <490000>;
+			regulator-max-microvolt = <980000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+
+		pm8953_l1: l1 {
+			regulator-min-microvolt = <968000>;
+			regulator-max-microvolt = <1152000>;
+		};
+
+		pm8953_l2: l2 {
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+		};
+
+		pm8953_l3: l3 {
+			regulator-min-microvolt = <1050000>;
+			regulator-max-microvolt = <1200000>;
+		};
+
+		pm8953_l4: l4 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8953_l5: l5 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8953_l6: l6 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+		};
+
+		pm8953_l7: l7 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8953_l8: l8 {
+			regulator-name = "irda_regulator";
+			regulator-min-microvolt = <2900000>;
+			regulator-max-microvolt = <2900000>;
+		};
+
+		pm8953_l9: l9 {
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8953_l10: l10 {
+			regulator-min-microvolt = <2948000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8953_l11: l11 {
+			regulator-min-microvolt = <2700000>;
+			regulator-max-microvolt = <3300000>;
+		};
+
+		pm8953_l12: l12 {
+			regulator-min-microvolt = <1648000>;
+			regulator-max-microvolt = <1800000>;
+			// regulator-max-microvolt = <3100000>;
+		};
+
+		pm8953_l13: l13 {
+			regulator-min-microvolt = <3050000>;
+			regulator-max-microvolt = <3100000>;
+		};
+
+		pm8953_l14: l14 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3052000>;
+		};
+
+		pm8953_l15: l15 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <3052000>;
+		};
+
+		pm8953_l16: l16 {
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+		};
+
+		pm8953_l17: l17 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2900000>;
+		};
+
+		pm8953_l19: l19 {
+			regulator-min-microvolt = <1350000>;
+			regulator-max-microvolt = <1350000>;
+		};
+
+		pm8953_l22: l22 {
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2900000>;
+		};
+
+		pm8953_l23: l23 {
+			regulator-min-microvolt = <800000>;
+			regulator-max-microvolt = <1000000>;
+		};
+	};
+};
+
+&sdhc_1 {
+	vmmc-supply = <&pm8953_l8>;
+	vqmmc-supply = <&pm8953_l5>;
+	status = "okay";
+};
+
+&sdhc_2 {
+	cd-gpios = <&tlmm 67 GPIO_ACTIVE_HIGH>;
+	vmmc-supply = <&pm8953_l11>;
+	vqmmc-supply = <&pm8953_l12>;
+	pinctrl-0 = <&sdc2_default &sdc2_cd_default>;
+	pinctrl-1 = <&sdc2_sleep &sdc2_cd_default>;
+	pinctrl-names = "default", "sleep";
+	status = "okay";
+};
+
+&sleep_clk {
+	clock-frequency = <32768>;
+};
+
+&tlmm {
+	gpio-reserved-ranges = <0 4>;
+
+	gpio_keys_default: gpio-keys-default-state {
+		pins = "gpio91";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-pull-up;
+	};
+
+	sdc2_cd_default: sdc2-cd-default-state {
+		pins = "gpio67";
+		function = "gpio";
+		drive-strength = <2>;
+		bias-disable;
+	};
+};
+
+&usb {
+	dr_mode = "peripheral";
+	extcon = <&usb_vbus>;
+	status = "okay";
+};
+
+&usb_hs_phy {
+	vdd-supply = <&pm8953_l23>;
+	vdda1p8-supply = <&pm8953_l7>;
+	vdda3p3-supply = <&pm8953_l13>;
+	status = "okay";
+};
+
+&wcnss {
+	vddpx-supply = <&pm8953_l5>;
+	status = "okay";
+};
+
+&wcnss_iris {
+	compatible = "qcom,wcn3620";
+	vddxo-supply = <&pm8953_l7>;
+	vddrfa-supply = <&pm8953_l19>;
+	vddpa-supply = <&pm8953_l9>;
+	vdddig-supply = <&pm8953_l5>;
+};
+
+&wcnss_mem {
+	status = "okay";
+};
+
+&xo_board {
+	clock-frequency = <19200000>;
+};


### PR DESCRIPTION
Add initial support for Xiaomi Redmi 8 (olive, olivelite and olivewood)

framebuffer, USB, eMMC, SD card, Wi-Fi, Bluetooth, UART and haptics work, touchscreen doesn't because there's no driver for each of 3 possible touchscreen models

`lm3697@36` is disabled by default because there's no proper way to determine which backlight IC driver should be used