### PR TITLE
arm64: dts: qcom: sdm439-nokia-panther: Add LED and vibrator

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdm439-nokia-panther.dts
+++ b/arch/arm64/boot/dts/qcom/sdm439-nokia-panther.dts
@@ -7,6 +7,7 @@
 
 #include <dt-bindings/arm/qcom,ids.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/leds/common.h>
 #include "sdm439.dtsi"
 #include "pm8953.dtsi"
 #include "pmi632.dtsi"
@@ -126,6 +127,20 @@
 
 &pm8953_resin {
 	linux,code = <KEY_VOLUMEDOWN>;
+	status = "okay";
+};
+
+&pmi632_lpg {
+	status = "okay";
+
+	led@1 {
+		reg = <1>;
+		color = <LED_COLOR_ID_WHITE>;
+		function = LED_FUNCTION_STATUS;
+	};
+};
+
+&pmi632_vib {
 	status = "okay";
 };
 


### PR DESCRIPTION
* output from evtest:

```
/dev/input/event0:      pm8941_pwrkey
/dev/input/event1:      pm8941_resin
/dev/input/event2:      gpio-keys
/dev/input/event3:      generic ft5x06 (67)
/dev/input/event4:      pm8xxx_vib_ffmemless
```

vibrator tested with fftest command.

* list of files in /sys/class/led:

```
mmc0:: -> ../../devices/platform/soc@0/7824900.mmc/leds/mmc0::
mmc1:: -> ../../devices/platform/soc@0/7864900.mmc/leds/mmc1::
white:status -> ../../devices/platform/soc@0/200f000.spmi/spmi-0/0-03/200f000.spmi:pmic@3:pwm/leds/white:status
```

led is tested with changing brightness in that sysfs.